### PR TITLE
Fix typo in inspection date table header

### DIFF
--- a/utils/TabularData.tsx
+++ b/utils/TabularData.tsx
@@ -82,7 +82,7 @@ const hpdViolationColumnMetadata: Map<
   ["apartment", { Header: "Apartment", dataType: ColumnDataTypes.STRING }],
   [
     "inspectiondate",
-    { Header: "Inpsection date", dataType: ColumnDataTypes.DATE },
+    { Header: "Inspection date", dataType: ColumnDataTypes.DATE },
   ],
   [
     "novdescription",


### PR DESCRIPTION
- there was a small typo in the header for inspection dates
- this PR just fixes that typo
- tbh, i didn't really want to do any dev setup, so i didn't build/test the app, but it's just a tiny fix

![image](https://github.com/cedarbaum/housecheck.nyc/assets/11168401/eacc0d7d-aaa4-4fb7-8949-b5788d6ad817)